### PR TITLE
Add an app.src file

### DIFF
--- a/src/erlcapnp.app.src
+++ b/src/erlcapnp.app.src
@@ -1,0 +1,4 @@
+{application, erlcapnp, [
+		{description, "capnproto library in erlang"},
+		{vsn, "1.0.0"}
+]}.


### PR DESCRIPTION
This is required in order to use erlcapnp as a rebar3 dependency.