### PR TITLE
Make encoding of list of list of text implemented

### DIFF
--- a/src/capnp_compile.erl
+++ b/src/capnp_compile.erl
@@ -958,7 +958,9 @@ ast_encode_ptr(N, PtrLen0, #ptr_type{type=list, extra={text, TextType}}, VarName
 	EncodeFun = make_atom(Line, append("encode_", TextType)),
 	StructSizePreformatted = {integer, Line, struct_pointer_header(0, 1)},
 	StructLen = {integer, Line, 1},
-	ast_encode_ptr_common(N, PtrLen0, fun ast_encode_struct_list_/3, [EncodeFun, StructSizePreformatted, StructLen], VarName, Line).
+	ast_encode_ptr_common(N, PtrLen0, fun ast_encode_struct_list_/3, [EncodeFun, StructSizePreformatted, StructLen], VarName, Line);
+ast_encode_ptr(N, PtrLen0, #ptr_type{}, VarName, Line) ->
+	ast_encode_ptr_common(N, PtrLen0, fun ast_encode_unknown_/3, [], VarName, Line).
 
 % This are the fragment that are inserted for each pointer.
 % All of them should have the same 'out' params:
@@ -998,6 +1000,23 @@ ast_encode_text_(
 			PointerAsInt = 0,
 			NewOffsetFromEnd = OldOffsetFromEnd
 	end.
+
+-ast_fragment2([]).
+ast_encode_unknown_(
+		{in, [OldOffsetFromEnd, OffsetToEnd, ValueToEncode]},
+		{out, [NewOffsetFromEnd, PointerAsInt, MainData, ExtraData]},
+		{temp, []}
+	) ->
+	if
+		ValueToEncode =:= undefined ->
+			ok;
+		true ->
+			erlang:error({cannot_encode, ValueToEncode})
+	end,
+	ExtraData = <<>>,
+	MainData = [],
+	PointerAsInt = 0,
+	NewOffsetFromEnd = OldOffsetFromEnd.
 
 -ast_fragment2([]).
 ast_encode_data_(

--- a/src/capnp_records.erl
+++ b/src/capnp_records.erl
@@ -86,6 +86,8 @@ field_type(Line, RecordName, #field_info{type=#ptr_type{type=list, extra={primit
 	or_preformat(Line, or_undefined(Line, {type, Line, list, [field_type(Line, RecordName, #field_info{type=Inner}, Schema)]}));
 field_type(Line, _RecordName, #field_info{type=#ptr_type{type=list, extra={text, _TextType}}}, _Schema) ->
 	or_preformat(Line, or_undefined(Line, {type, Line, list, [or_undefined(Line, {type, Line, iodata, []})]}));
+field_type(Line, _RecordName, #field_info{type=#ptr_type{type=list, extra={list, {text, _TextType}}}}, _Schema) ->
+	or_preformat(Line, or_undefined(Line, {type, Line, list, [or_undefined(Line, {type, Line, list, [or_undefined(Line, {type, Line, iodata, []})]})]}));
 field_type(Line, _RecordName, #field_info{type=#ptr_type{type=list, extra={struct, #ptr_type{type=struct, extra={_TypeName, _DataLen, _PtrLen}}}}}, _Schema) ->
 	% Recursive call is or_undefined, which is not allowed here!
 	{type, Line, any, []};

--- a/src/capnp_schema_wrangle.erl
+++ b/src/capnp_schema_wrangle.erl
@@ -219,9 +219,12 @@ type_info(list, {enum, #'Type_enum'{typeId=TypeId}}, Schema) ->
 type_info(list, {TextType, undefined}, _Schema) when TextType =:= text; TextType =:= data ->
 	% List of text types; this is a list-of-lists.
 	{64, #ptr_type{type=list, extra={text, TextType}}};
-type_info(list, {PtrType, _LTypeDescription}, _Schema) when PtrType =:= list; PtrType =:= text; PtrType =:= data ->
+type_info(list, {list, {TextType, undefined}}, _Schema) when TextType =:= text; TextType =:= data ->
+	% List of text types; this is a list-of-lists.
+	{64, #ptr_type{type=list, extra={list, {text, TextType}}}};
+type_info(list, {PtrType, LTypeDescription}, _Schema) when PtrType =:= list ->
 	% List of list, or list-of-(text or data) -- all three are lists of lists of lists.
-	erlang:error({not_implemented, list, list}); % TODO
+	erlang:error({not_implemented, list, list, LTypeDescription}); % TODO
 type_info(list, {PrimitiveType, undefined}, _Schema) ->
 	% List of any normal primitive type.
 	{64, #ptr_type{type=list, extra={primitive, builtin_info(PrimitiveType)}}};


### PR DESCRIPTION
When you have `List(List(Text))` in your schema with this commits you will be able to compile the schema. The failure is postponed to the actual encoding. 

This is useful when you have such a type in your schema but the Erlang part of the application does not encode it.

This code is actually @bucko909's, I'm just committing it.