### PR TITLE
Decode List(Text) encoded by other tools

### DIFF
--- a/src/capnp_schema.erl
+++ b/src/capnp_schema.erl
@@ -3181,7 +3181,10 @@ follow_data_pointer(PointerInt, MessageRef) ->
 follow_struct_list_pointer(_DecodeFun, 0, _MessageRef) ->
     undefined;
 follow_struct_list_pointer(DecodeFun, PointerInt, MessageRef)
-    when PointerInt band 3 == 1 ->
+    when
+        PointerInt band 3 == 1
+        andalso
+        (PointerInt bsr 32) band 7 >= 5 ->
     PointerOffset =
         case PointerInt band (1 bsl 31) of
             0 ->
@@ -3189,19 +3192,44 @@ follow_struct_list_pointer(DecodeFun, PointerInt, MessageRef)
             _ ->
                 (PointerInt bsr 2) band (1 bsl 30 - 1) - (1 bsl 30) + 1
         end,
+    LengthFromPointer = (PointerInt bsr 35) band (1 bsl 29 - 1),
     NewOffset = MessageRef#message_ref.current_offset + PointerOffset,
-    SkipBits = NewOffset bsl 6,
-    <<_:SkipBits,Tag:64/little-unsigned-integer,_/binary>> =
-        MessageRef#message_ref.current_segment,
-    Length = (Tag bsr 2) band (1 bsl 30 - 1),
-    DWords = (Tag bsr 32) band (1 bsl 16 - 1),
-    PWords = (Tag bsr 48) band (1 bsl 16 - 1),
+    case (PointerInt bsr 32) band 7 of
+        5 ->
+            Length = LengthFromPointer,
+            DWords = 1,
+            PWords = 0,
+            ListStartOffset = NewOffset;
+        6 ->
+            Length = LengthFromPointer,
+            DWords = 0,
+            PWords = 1,
+            ListStartOffset = NewOffset;
+        7 ->
+            SkipBits = NewOffset bsl 6,
+            <<_:SkipBits,Tag:64/little-unsigned-integer,_/binary>> =
+                MessageRef#message_ref.current_segment,
+            0 = Tag band 3,
+            Length = (Tag bsr 2) band (1 bsl 30 - 1),
+            DWords = (Tag bsr 32) band (1 bsl 16 - 1),
+            PWords = (Tag bsr 48) band (1 bsl 16 - 1),
+            LengthFromPointer = Length * (DWords + PWords),
+            ListStartOffset = NewOffset + 1
+    end,
     decode_struct_list(DecodeFun,
                        Length,
                        DWords,
                        PWords,
                        MessageRef#message_ref{current_offset =
-                                                  NewOffset + 1});
+                                                  ListStartOffset});
+follow_struct_list_pointer(_DecodeFun, PointerInt, _MessageRef)
+    when
+        PointerInt band 3 == 1
+        andalso
+        (PointerInt bsr 32) band 7 < 5 ->
+    error({not_supported,
+           "cannot currently decode List(struct {}) which is stored as "
+           "a list of subword values"});
 follow_struct_list_pointer(DecodeFun,
                            PointerInt,
                            MessageRef = #message_ref{})

--- a/src/erlcapnp_test1.erl
+++ b/src/erlcapnp_test1.erl
@@ -2056,6 +2056,38 @@ follow_int8_list_pointer(PointerInt, MessageRef)
          <<X:8/little-signed-integer>> <= ListData
     ].
 
+follow_struct_list_pointer(_DecodeFun, 0, _MessageRef) ->
+    undefined;
+follow_struct_list_pointer(DecodeFun, PointerInt, MessageRef)
+    when PointerInt band 3 == 1 ->
+    PointerOffset =
+        case PointerInt band (1 bsl 31) of
+            0 ->
+                (PointerInt bsr 2) band (1 bsl 30 - 1) + 1;
+            _ ->
+                (PointerInt bsr 2) band (1 bsl 30 - 1) - (1 bsl 30) + 1
+        end,
+    NewOffset = MessageRef#message_ref.current_offset + PointerOffset,
+    SkipBits = NewOffset bsl 6,
+    <<_:SkipBits,Tag:64/little-unsigned-integer,_/binary>> =
+        MessageRef#message_ref.current_segment,
+    Length = (Tag bsr 2) band (1 bsl 30 - 1),
+    DWords = (Tag bsr 32) band (1 bsl 16 - 1),
+    PWords = (Tag bsr 48) band (1 bsl 16 - 1),
+    decode_struct_list(DecodeFun,
+                       Length,
+                       DWords,
+                       PWords,
+                       MessageRef#message_ref{current_offset =
+                                                  NewOffset + 1});
+follow_struct_list_pointer(DecodeFun,
+                           PointerInt,
+                           MessageRef = #message_ref{})
+    when PointerInt band 3 == 2 ->
+    {NewPointerInt,NewMessageRef} =
+        decode_far_pointer(PointerInt, MessageRef),
+    follow_struct_list_pointer(DecodeFun, NewPointerInt, NewMessageRef).
+
 follow_struct_pointer(_DecodeFun, 0, _MessageRef) ->
     undefined;
 follow_struct_pointer(DecodeFun, PointerInt, MessageRef)
@@ -2085,40 +2117,6 @@ follow_struct_pointer(DecodeFun,
     {NewPointerInt,NewMessageRef} =
         decode_far_pointer(PointerInt, MessageRef),
     follow_struct_pointer(DecodeFun, NewPointerInt, NewMessageRef).
-
-follow_tagged_struct_list_pointer(_DecodeFun, 0, _MessageRef) ->
-    undefined;
-follow_tagged_struct_list_pointer(DecodeFun, PointerInt, MessageRef)
-    when PointerInt band 3 == 1 ->
-    PointerOffset =
-        case PointerInt band (1 bsl 31) of
-            0 ->
-                (PointerInt bsr 2) band (1 bsl 30 - 1) + 1;
-            _ ->
-                (PointerInt bsr 2) band (1 bsl 30 - 1) - (1 bsl 30) + 1
-        end,
-    NewOffset = MessageRef#message_ref.current_offset + PointerOffset,
-    SkipBits = NewOffset bsl 6,
-    <<_:SkipBits,Tag:64/little-unsigned-integer,_/binary>> =
-        MessageRef#message_ref.current_segment,
-    Length = (Tag bsr 2) band (1 bsl 30 - 1),
-    DWords = (Tag bsr 32) band (1 bsl 16 - 1),
-    PWords = (Tag bsr 48) band (1 bsl 16 - 1),
-    decode_struct_list(DecodeFun,
-                       Length,
-                       DWords,
-                       PWords,
-                       MessageRef#message_ref{current_offset =
-                                                  NewOffset + 1});
-follow_tagged_struct_list_pointer(DecodeFun,
-                                  PointerInt,
-                                  MessageRef = #message_ref{})
-    when PointerInt band 3 == 2 ->
-    {NewPointerInt,NewMessageRef} =
-        decode_far_pointer(PointerInt, MessageRef),
-    follow_tagged_struct_list_pointer(DecodeFun,
-                                      NewPointerInt,
-                                      NewMessageRef).
 
 follow_text_or_data_pointer(0, _MessageRef, _Trail) ->
     undefined;
@@ -2279,19 +2277,19 @@ internal_decode_erlcapnp_TestCompositeList(<<>>,
                                              VartestVar2:64/little-unsigned-integer>>,
                                            MessageRef) ->
     #erlcapnp_TestCompositeList{testVar1 =
-                                    follow_tagged_struct_list_pointer(fun internal_decode_erlcapnp_TestMultipleIntegers/3,
-                                                                      VartestVar1,
-                                                                      MessageRef#message_ref{current_offset =
-                                                                                                 MessageRef#message_ref.current_offset
-                                                                                                 +
-                                                                                                 0}),
+                                    follow_struct_list_pointer(fun internal_decode_erlcapnp_TestMultipleIntegers/3,
+                                                               VartestVar1,
+                                                               MessageRef#message_ref{current_offset =
+                                                                                          MessageRef#message_ref.current_offset
+                                                                                          +
+                                                                                          0}),
                                 testVar2 =
-                                    follow_tagged_struct_list_pointer(fun internal_decode_erlcapnp_TestLessBoringPointer/3,
-                                                                      VartestVar2,
-                                                                      MessageRef#message_ref{current_offset =
-                                                                                                 MessageRef#message_ref.current_offset
-                                                                                                 +
-                                                                                                 1})};
+                                    follow_struct_list_pointer(fun internal_decode_erlcapnp_TestLessBoringPointer/3,
+                                                               VartestVar2,
+                                                               MessageRef#message_ref{current_offset =
+                                                                                          MessageRef#message_ref.current_offset
+                                                                                          +
+                                                                                          1})};
 internal_decode_erlcapnp_TestCompositeList(Data,
                                            Pointers,
                                            MessageRef = #message_ref{}) ->
@@ -2755,12 +2753,12 @@ internal_decode_erlcapnp_TestPointerList(<<>>,
                                          <<VartestVar1:64/little-unsigned-integer>>,
                                          MessageRef) ->
     #erlcapnp_TestPointerList{testVar1 =
-                                  follow_tagged_struct_list_pointer(fun internal_decode_erlcapnp_TestBoringPointer/3,
-                                                                    VartestVar1,
-                                                                    MessageRef#message_ref{current_offset =
-                                                                                               MessageRef#message_ref.current_offset
-                                                                                               +
-                                                                                               0})};
+                                  follow_struct_list_pointer(fun internal_decode_erlcapnp_TestBoringPointer/3,
+                                                             VartestVar1,
+                                                             MessageRef#message_ref{current_offset =
+                                                                                        MessageRef#message_ref.current_offset
+                                                                                        +
+                                                                                        0})};
 internal_decode_erlcapnp_TestPointerList(Data,
                                          Pointers,
                                          MessageRef = #message_ref{}) ->
@@ -2853,19 +2851,19 @@ internal_decode_erlcapnp_TestShortList(<<>>,
                                          VartestVar2:64/little-unsigned-integer>>,
                                        MessageRef) ->
     #erlcapnp_TestShortList{testVar1 =
-                                follow_tagged_struct_list_pointer(fun internal_decode_erlcapnp_TestBoringInteger/3,
-                                                                  VartestVar1,
-                                                                  MessageRef#message_ref{current_offset =
-                                                                                             MessageRef#message_ref.current_offset
-                                                                                             +
-                                                                                             0}),
+                                follow_struct_list_pointer(fun internal_decode_erlcapnp_TestBoringInteger/3,
+                                                           VartestVar1,
+                                                           MessageRef#message_ref{current_offset =
+                                                                                      MessageRef#message_ref.current_offset
+                                                                                      +
+                                                                                      0}),
                             testVar2 =
-                                follow_tagged_struct_list_pointer(fun internal_decode_erlcapnp_SimpleShortStruct/3,
-                                                                  VartestVar2,
-                                                                  MessageRef#message_ref{current_offset =
-                                                                                             MessageRef#message_ref.current_offset
-                                                                                             +
-                                                                                             1})};
+                                follow_struct_list_pointer(fun internal_decode_erlcapnp_SimpleShortStruct/3,
+                                                           VartestVar2,
+                                                           MessageRef#message_ref{current_offset =
+                                                                                      MessageRef#message_ref.current_offset
+                                                                                      +
+                                                                                      1})};
 internal_decode_erlcapnp_TestShortList(Data,
                                        Pointers,
                                        MessageRef = #message_ref{}) ->
@@ -2895,12 +2893,12 @@ internal_decode_erlcapnp_TestTextList(<<>>,
                                       <<VartestVar1:64/little-unsigned-integer>>,
                                       MessageRef) ->
     #erlcapnp_TestTextList{testVar1 =
-                               follow_tagged_struct_list_pointer(fun internal_decode_text/3,
-                                                                 VartestVar1,
-                                                                 MessageRef#message_ref{current_offset =
-                                                                                            MessageRef#message_ref.current_offset
-                                                                                            +
-                                                                                            0})};
+                               follow_struct_list_pointer(fun internal_decode_text/3,
+                                                          VartestVar1,
+                                                          MessageRef#message_ref{current_offset =
+                                                                                     MessageRef#message_ref.current_offset
+                                                                                     +
+                                                                                     0})};
 internal_decode_erlcapnp_TestTextList(Data,
                                       Pointers,
                                       MessageRef = #message_ref{}) ->

--- a/src/erlcapnp_test1.erl
+++ b/src/erlcapnp_test1.erl
@@ -2059,7 +2059,10 @@ follow_int8_list_pointer(PointerInt, MessageRef)
 follow_struct_list_pointer(_DecodeFun, 0, _MessageRef) ->
     undefined;
 follow_struct_list_pointer(DecodeFun, PointerInt, MessageRef)
-    when PointerInt band 3 == 1 ->
+    when
+        PointerInt band 3 == 1
+        andalso
+        (PointerInt bsr 32) band 7 >= 5 ->
     PointerOffset =
         case PointerInt band (1 bsl 31) of
             0 ->
@@ -2067,19 +2070,44 @@ follow_struct_list_pointer(DecodeFun, PointerInt, MessageRef)
             _ ->
                 (PointerInt bsr 2) band (1 bsl 30 - 1) - (1 bsl 30) + 1
         end,
+    LengthFromPointer = (PointerInt bsr 35) band (1 bsl 29 - 1),
     NewOffset = MessageRef#message_ref.current_offset + PointerOffset,
-    SkipBits = NewOffset bsl 6,
-    <<_:SkipBits,Tag:64/little-unsigned-integer,_/binary>> =
-        MessageRef#message_ref.current_segment,
-    Length = (Tag bsr 2) band (1 bsl 30 - 1),
-    DWords = (Tag bsr 32) band (1 bsl 16 - 1),
-    PWords = (Tag bsr 48) band (1 bsl 16 - 1),
+    case (PointerInt bsr 32) band 7 of
+        5 ->
+            Length = LengthFromPointer,
+            DWords = 1,
+            PWords = 0,
+            ListStartOffset = NewOffset;
+        6 ->
+            Length = LengthFromPointer,
+            DWords = 0,
+            PWords = 1,
+            ListStartOffset = NewOffset;
+        7 ->
+            SkipBits = NewOffset bsl 6,
+            <<_:SkipBits,Tag:64/little-unsigned-integer,_/binary>> =
+                MessageRef#message_ref.current_segment,
+            0 = Tag band 3,
+            Length = (Tag bsr 2) band (1 bsl 30 - 1),
+            DWords = (Tag bsr 32) band (1 bsl 16 - 1),
+            PWords = (Tag bsr 48) band (1 bsl 16 - 1),
+            LengthFromPointer = Length * (DWords + PWords),
+            ListStartOffset = NewOffset + 1
+    end,
     decode_struct_list(DecodeFun,
                        Length,
                        DWords,
                        PWords,
                        MessageRef#message_ref{current_offset =
-                                                  NewOffset + 1});
+                                                  ListStartOffset});
+follow_struct_list_pointer(_DecodeFun, PointerInt, _MessageRef)
+    when
+        PointerInt band 3 == 1
+        andalso
+        (PointerInt bsr 32) band 7 < 5 ->
+    error({not_supported,
+           "cannot currently decode List(struct {}) which is stored as "
+           "a list of subword values"});
 follow_struct_list_pointer(DecodeFun,
                            PointerInt,
                            MessageRef = #message_ref{})


### PR DESCRIPTION
Without this, a `List(Text)` (which is `List(List(Int8))`) which is not
encodeded as `List(struct { x @0 :Text; })`, will decode the first text
pointer as a tag and get very wrong answers. The patch:

* Makes sure we give a sensible error for unsupported types.
* Provides better checking that data is correctly formatted.
* Also adds support for decoding `List(Text)` correctly, as well as
  decoding `List(struct {})` which was upgraded from `List(Int64)` or
  `List(AnyPointer)` (or compatible types).

We still don't support double lists.

This relates to Issue #3 (which relies on the upgrade decoding for its
`List(Text)` encoding to be valid).